### PR TITLE
[WIP] Enforce numerical magnitudes in json file

### DIFF
--- a/data/ucumDefs.json
+++ b/data/ucumDefs.json
@@ -467,7 +467,7 @@
       "csCode_": "10*",
       "ciCode_": "10*",
       "property_": "number",
-      "magnitude_": "10",
+      "magnitude_": 10,
       "dim_": {
         "dimVec_": [
           0,
@@ -505,7 +505,7 @@
       "csCode_": "10^",
       "ciCode_": "10^",
       "property_": "number",
-      "magnitude_": "10",
+      "magnitude_": 10,
       "dim_": {
         "dimVec_": [
           0,

--- a/source/ucumXmlDocument.js
+++ b/source/ucumXmlDocument.js
@@ -244,7 +244,7 @@ export class UcumXmlDocument {
           attrs['baseFactor_'] = 1 ;
         }
         else if (attrs['csCode_'] === '[pH]') {
-          attrs['baseFactor_'] = funcNode.attr.value ;
+          attrs['baseFactor_'] = parseFloat(funcNode.attr.value) ;
         }
         else {
           let slashPos = attrs['csUnitString_'].indexOf('/');
@@ -266,7 +266,7 @@ export class UcumXmlDocument {
           }
           // unit string = m1/s4/Hz, K, deg, V, mV, uV, nV, W, kW
           else {
-            attrs['baseFactor_'] = funcNode.attr.value;
+            attrs['baseFactor_'] = parseFloat(funcNode.attr.value);
           }
         } // end if the unit string is not 1
       } // end if the unit is special
@@ -291,7 +291,7 @@ export class UcumXmlDocument {
           attrs['baseFactor_'] = parseFloat(valNode.attr.value) ;
         }
         else {
-          attrs['baseFactor_'] = valNode.val;
+          attrs['baseFactor_'] = parseFloat(valNode.val);
         }
       } // end if this is not a special unit
 
@@ -328,7 +328,7 @@ export class UcumXmlDocument {
         else if (attrs['csUnitString_'].substr(0,3) == "10*") {
           let exp = parseInt(attrs['csUnitString_'].substr(3));
           attrs['magnitude_'] = Math.pow(10, exp) ;
-          if (attrs['baseFactor_'] !== '1') {
+          if (attrs['baseFactor_'] !== 1) {
             attrs['magnitude_'] *= attrs['baseFactor_'];
           }
         }


### PR DESCRIPTION
All of the entries in the `ucumDefs.json` file are numerical except for two strings. It's not a huge deal to wrap whatever codes using this with a numerical conversion, but it'd just be easier to use if this field behaved as expected.