### PR TITLE
chore: add ts types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "path": "^0.12.7",
         "semver": "^5.5.1",
         "time-grunt": "^1.4.0",
+        "typescript": "^5.8.2",
         "webpack": "^5.20.2",
         "webpack-cli": "^5.0.1"
       }
@@ -6845,6 +6846,20 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.1.2",
   "description": "Implements Unified Code for Units of Measure (UCUM) functions in a javascript library",
   "main": "source-cjs/ucumPkg.js",
+  "types": "types/index.d.ts",
   "homepage": "https://lhncbc.github.io/ucum-lhc/",
   "directories": {
     "test": "test"
@@ -11,7 +12,8 @@
     "browser-dist/ucum-lhc.min.*",
     "source-cjs/*",
     "source/*",
-    "data/ucumDefs.min.json"
+    "data/ucumDefs.min.json",
+    "types/*"
   ],
   "dependencies": {
     "coffeescript": "^2.7.0",
@@ -48,6 +50,7 @@
     "path": "^0.12.7",
     "semver": "^5.5.1",
     "time-grunt": "^1.4.0",
+    "typescript": "^5.8.2",
     "webpack": "^5.20.2",
     "webpack-cli": "^5.0.1"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,195 @@
+declare module "@lhncbc/ucum-lhc" {
+  export type Ucum = {
+    dimLen_: number;
+    validOps_: string[];
+    codeSep_: string;
+    valMsgStart_: string;
+    valMsgEnd_: string;
+    cnvMsgStart_: string;
+    cnvMsgEnd_: string;
+    openEmph_: string;
+    closeEmph_: string;
+    openEmphHTML_: string;
+    closeEmphHTML_: string;
+    braceMsg_: string;
+    needMoleWeightMsg_: string;
+    needEqWeightMsg_: string;
+    needEqChargeMsg_: string;
+    csvCols_: Record<string, string>;
+    inputKey_: string;
+    specUnits_: Record<string, string>;
+  };
+
+  export class UcumLhcUtils {
+    static getInstance(): UcumLhcUtils;
+
+    constructor();
+
+    useHTMLInMessage(use?: string): void;
+
+    useBraceMsgForEarchString(use?: string): void;
+
+    validateUnitString(
+      uStr: string,
+      suggest?: false,
+      valConv?: string,
+    ): ValidateUnitStringResult;
+    validateUnitString(
+      uStr: string,
+      suggest?: true,
+      valConv?: string,
+    ): ValidateUnitStringResult & {
+      suggestions: Suggestion[];
+    };
+
+    detectConversionType(
+      fromUnit: object,
+      toUnit: object,
+    ): "normal" | "mol|mass" | "eq|mass" | "eq|mol" | "eq|mol|mass";
+
+    convertUnitTo(
+      fromUnitCode: string,
+      fromVal: number | string,
+      toUnitCode: string,
+      options?: { suggest?: boolean; molecularWeight?: number; charge: number },
+    ): {
+      status: "succeeded" | "failed" | "errror";
+      toVal: number | null;
+      msg: string[];
+      suggestions: {
+        from: {
+          msg: string;
+          invalidUnit: string;
+          units: string[];
+        };
+        to: {
+          msg: string;
+          invalidUnit: string;
+          units: string[];
+        };
+      };
+      fromUnit: string;
+      toUnit: string;
+    };
+
+    convertToBaseUnits(
+      fromUnit: string,
+      fromVal: number | string,
+    ): {
+      status: "succeeded" | "invalid" | "failed" | "errror";
+      msg: string[];
+      magnitude: number;
+      fromUnitIsSpecial: boolean;
+      unitToExp: Record<string, number>;
+    };
+
+    checkSynonyms(theSyn: string): {
+      status: "succeeded" | "failed" | "error";
+      msg: string;
+      units: Unit[];
+    };
+
+    getSpecifiedUnit(
+      uName: string,
+      valConv: "validate" | "convert",
+      suggest: false,
+    ): GetSpecifiedUnitResult & {
+      suggestions: null;
+    };
+    getSpecifiedUnit(
+      uName: string,
+      valConv: "validate" | "convert",
+      suggest: true,
+    ): GetSpecifiedUnitResult & {
+      suggestions: Suggestion[];
+    };
+
+    commensurablesList(
+      fromName: string,
+      categoryList?: string[] | null,
+    ): [Unit[], string];
+  }
+
+  export class UnitTables {
+    constructor();
+
+    static getInstance(): UnitTables;
+
+    unitsCount(): number;
+
+    addUnit(theUnit: Unit): void;
+
+    addUnitName(theUnit: Unit): void;
+
+    addUnitCode(theUnit: Unit): void;
+
+    addUnitString(theUnit: Unit): void;
+
+    addUnitDimension(theUnit: Unit): void;
+
+    buildUnitSynonyms(): void;
+
+    addSynonymCodes(theCode: string, theSynonyms: string[]): void;
+
+    getUnitByCode(uCode: string): Unit | null;
+
+    getUnitByName(uName: string): Unit[] | null;
+
+    getUnitByString(uString: string): Unit[] | null;
+
+    getUnitsByDimension(uDim: string): Unit[] | null;
+
+    getUnitBySynonym(uSyn: string):
+      | {
+          status: "succeeded";
+          units: Unit[];
+        }
+      | {
+          status: "failed" | "error";
+          msg: string;
+        };
+
+    getAllUnitNames(): string[];
+
+    getUnitNamesList(): string[];
+
+    getMassDimensionIndex(): number;
+
+    compareCodes(a: string, b: string): -1 | 1;
+
+    getAllUnitCodes(): string[];
+
+    allUnitsByDef(): Unit[];
+
+    allUnitsByName(cols: string[], sep: string): string;
+
+    printUnits(doLong: boolean, sep: string): string;
+  }
+
+  type Dimension = {};
+
+  type Unit = {
+    name_: string;
+    csCode_: string;
+  };
+
+  type ValidateUnitStringResult = {
+    status: "valid" | "invalid" | "error";
+    ucumCode: string;
+    msg: string[];
+    unit: Unit;
+  };
+
+  type GetSpecifiedUnitResult = {
+    status: "valid" | "invalid" | "error";
+    unit: Unit | null;
+    origString: string;
+    retMsg: string[];
+  };
+
+  type Suggestion = {
+    msg: string;
+    invalidUnit: string;
+    units: [code: string, name: string, guidance: string][];
+  };
+}


### PR DESCRIPTION
This is a proposal for typescript types.

I've included everything that's exported by `ucumPkg.js` but maybe that's too much.

And there is something weird with `Unit` and `UnitTables` which I'm not sure how to handle.
In the readme, about `commensurablesList` the doc say that only `name_` and `csCode_`should be relied upon in the `Unit` class, but some methods from `UnitTables` take a `Unit` and expect it to have some other properties, like `csUnitString_` for `addUnitString` or `dim_` for `addUnitDimension`.
I could not include `UnitTables` but I'm using `getAllUnitCode`. I could also specify these additional properties, either directly on the `Unit` class or only for the relevant `UnitTables` methods properties.